### PR TITLE
turn off game specific behaviors based on time

### DIFF
--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -1106,7 +1106,9 @@ phase_of_the_moon() /* 0-7, with 0: new, 4: full */
     if ((epact == 25 && goldn > 11) || epact == 24)
         epact++;
 
-    return ((((((diy + epact) * 6) + 11) % 177) / 22) & 7);
+    // return ((((((diy + epact) * 6) + 11) % 177) / 22) & 7);
+    // turn off game changes based on phase_of_the_moon
+    return 1;
 }
 
 boolean
@@ -1115,7 +1117,9 @@ friday_13th()
     register struct tm *lt = getlt();
 
     /* tm_wday (day of week; 0==Sunday) == 5 => Friday */
-    return (boolean) (lt->tm_wday == 5 && lt->tm_mday == 13);
+    // return (boolean) (lt->tm_wday == 5 && lt->tm_mday == 13);
+    // turn off game changes based on friday_13th
+    return (boolean) 0;
 }
 
 int
@@ -1123,13 +1127,17 @@ night()
 {
     register int hour = getlt()->tm_hour;
 
-    return (hour < 6 || hour > 21);
+    // return (hour < 6 || hour > 21);
+    // turn off game changes based on night
+    return 0;
 }
 
 int
 midnight()
 {
-    return (getlt()->tm_hour == 0);
+    // return (getlt()->tm_hour == 0);
+    // turn off game changes based on midnight
+    return 0;
 }
 
 /* strbuf_init() initializes strbuf state for use */


### PR DESCRIPTION
It turns out that the game is somehow different based on local time https://nethackwiki.com/wiki/Time. For reproducibility and evaluation reasons we shouldn't allow this changes. For example my agent score dropped from 5k to 3k just because it was full moon. 

I turned off all four such cases. moon phases, friday 13th, midnight, and night. 
  