### PR TITLE
Fix typo in Docker instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ architecture do:
 ```bash
 $ git clone https://github.com/heiner/nle --recursive
 $ cd nle
-$ docker build -file docker/Dockerfile-jammy . -tag nle
+$ docker build --file docker/Dockerfile-jammy . --tag nle
 $ docker run -it --gpus all --rm --name nle nle
 # or alternatively if you don't have GPUs
 $ docker run -it --name nle nle


### PR DESCRIPTION
Fix the typos in the 'docker build' command in the README.

See issue #24  for details.