### PR TITLE
Upgrade artifact GitHub actions

### DIFF
--- a/.github/workflows/lint_cc.yml
+++ b/.github/workflows/lint_cc.yml
@@ -11,7 +11,7 @@ jobs:
     name: clang-format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: DoozyX/clang-format-lint-action@v0.12
         with:
           source: win/rl src/nle.c sys/unix/nledl.c include/nle.h include/nledl.h

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -108,7 +108,7 @@ jobs:
           popd
       - name: Save sdist
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-sdist
           path: dist/
@@ -117,7 +117,7 @@ jobs:
     needs: test_repo
     runs-on: ubuntu-20.04 # Can be also run for macOS
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up QEMU # Required for building manylinux aarch64 wheels on x86_64
@@ -141,7 +141,7 @@ jobs:
           # Set NLE_RELEASE_BUILD to 1 to build release wheels
           CIBW_ENVIRONMENT: "NLE_RELEASE_BUILD=1"
       - name: Save wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-wheels
           path: ./wheelhouse/*.whl
@@ -160,7 +160,7 @@ jobs:
         with:
           submodules: true
       - name: Get wheels artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheels
           path: dist
@@ -195,12 +195,12 @@ jobs:
           echo "${{ github.event.release.tag_name }}"
           [[ "${{ github.event.release.tag_name }}" == "v$(cat version.txt)" ]]
       - name: Get sdist artifact # Get sdist artifact from the test_sdist job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-sdist
           path: dist
       - name: Get wheels artifacts # Get wheels artifacts from the build_wheels job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheels
           path: dist
@@ -236,12 +236,12 @@ jobs:
           echo "${{ github.event.release.tag_name }}"
           [[ "${{ github.event.release.tag_name }}" == "v$(cat version.txt)" ]]
       - name: Get sdist artifact # Get sdist artifact from the test_sdist job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-sdist
           path: dist
       - name: Get wheels artifacts # Get wheels artifacts from the build_wheels job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-wheels
           path: dist

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
     steps:
     - name: Setup Python ${{ matrix.python-version }} env
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Ensure latest pip & wheel


### PR DESCRIPTION
GitHub is deprecating v3 of upload-artifact and download-artifact workflow actions from the end of November 2024. 

See here for details: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

To comply with this, the PR changes:
- All references to actions/upload-artifact to v4
- All references to actions/download-artifact to v4

In addition, the PR implements consistent references to other actions across the workflows
- Standardize references to actions/checkout to v4
- Standardize references to actions/setup-python to v5