### PR TITLE
Update setup.py to use Gymnasium 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         ext_modules=[setuptools.Extension("nle", sources=[])],
         cmdclass={"build_ext": CMakeBuild},
         setup_requires=["pybind11>=2.2"],
-        install_requires=["pybind11>=2.2", "numpy>=1.16", "gymnasium==0.29.1"],
+        install_requires=["pybind11>=2.2", "numpy>=1.16", "gymnasium==1.0.0"],
         extras_require=extras_deps,
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
Update setup to use Gymnasium v1.0.0

This shouldn't require any changes as we are already compliant with the API from v0.29.1 and there's nothing that jumps out from the release notes that affects NLE.

This PR addresses issue #38.