### PR TITLE
Add tests and wheel for Python 3.12

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Ensure latest pip & wheel
-        run: python -m pip install -q --upgrade pip wheel
+      - name: Ensure latest pip, wheel & setuptools
+        run: python -m pip install -q --upgrade pip wheel setuptools
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
@@ -53,8 +53,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.8
-      - name: Ensure latest pip & wheel
-        run: python -m pip install -q --upgrade pip wheel
+      - name: Ensure latest pip, wheel & setuptools
+        run: python -m pip install -q --upgrade pip wheel setuptools
       - name: Install dependencies
         run: |
           brew install cmake
@@ -84,8 +84,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Ensure latest pip & wheel
-        run: python -m pip install -q --upgrade pip wheel
+      - name: Ensure latest pip, wheel & setuptools
+        run: python -m pip install -q --upgrade pip wheel setuptools
       - name: Install dependencies
         run: |
           brew install cmake
@@ -154,8 +154,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Ensure latest pip & wheel
-        run: python -m pip install -q --upgrade pip wheel
+      - name: Ensure latest pip, wheel & setuptools
+        run: python -m pip install -q --upgrade pip wheel tools
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-20.04, macos-latest]
       fail-fast: false
     steps:
@@ -129,7 +129,7 @@ jobs:
         if: github.event_name != 'release'
         uses: pypa/cibuildwheel@v2.19.2 # The main configuration is in pyproject.toml
         env:
-          CIBW_BUILD: "cp311-manylinux*" # Build only python 3.11 wheels for testing
+          CIBW_BUILD: "cp312-manylinux*" # Build only python 3.12 wheels for testing
           # Increase verbosity to see what's going on in the build in case of failure
           CIBW_BUILD_VERBOSITY: 3
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,15 +75,15 @@ jobs:
           pushd ..
           python -m pytest --import-mode=append -svx $REPONAME/nle/tests
           popd
-  test_sdist_3_11:
-    name: Test sdist on MacOS w/ Py3.11
+  test_sdist_3_12:
+    name: Test sdist on MacOS w/ Py3.12
     needs: test_repo
     runs-on: macos-latest
     steps:
-      - name: Setup Python 3.11 env
+      - name: Setup Python 3.12 env
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Ensure latest pip & wheel
         run: python -m pip install -q --upgrade pip wheel
       - name: Install dependencies
@@ -145,15 +145,15 @@ jobs:
         with:
           name: python-wheels
           path: ./wheelhouse/*.whl
-  test_manylinux_3_11:
-    name: Test manylinux wheel on Ubuntu w/ Py3.11
+  test_manylinux_3_12:
+    name: Test manylinux wheel on Ubuntu w/ Py3.12
     needs: build_wheels
     runs-on: ubuntu-20.04
     steps:
-      - name: Setup Python 3.11 env
+      - name: Setup Python 3.12 env
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Ensure latest pip & wheel
         run: python -m pip install -q --upgrade pip wheel
       - uses: actions/checkout@v4
@@ -166,7 +166,7 @@ jobs:
           path: dist
       - name: Install from wheel # Install wheel mathcing the Python version and architecture
         run: | 
-          WHEELNAME=$(ls dist/*311*manylinux*x86_64*.whl) 
+          WHEELNAME=$(ls dist/*312*manylinux*x86_64*.whl) 
           MODE="[all]"
           pip install "$WHEELNAME$MODE"
       - name: Run tests outside repo dir
@@ -179,7 +179,7 @@ jobs:
   # Use prereleases to test publish the artefacts to testpypi
   test_deploy:
     name: Deploy artefacts to testpypi
-    needs: [test_sdist_3_11, test_manylinux_3_11]
+    needs: [test_sdist_3_12, test_manylinux_3_12]
     if: github.event_name == 'release' && github.event.action == 'prereleased'
     runs-on: ubuntu-latest
     environment:
@@ -220,7 +220,7 @@ jobs:
   #      functionalities like workflow dependencies :|
   deploy_sdist:
     name: Deploy sdist to pypi
-    needs: [test_sdist_3_11, test_manylinux_3_11]  
+    needs: [test_sdist_3_12, test_manylinux_3_12]  
     if: github.event_name == 'release' && github.event.action == 'released'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     steps:
     - name: Setup Python ${{ matrix.python-version }} env

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -19,8 +19,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Ensure latest pip & wheel
-      run: "python -m pip install -q --upgrade pip wheel"
+    - name: Ensure latest pip, wheel & setuptools
+      run: "python -m pip install -q --upgrade pip wheel setuptools"
     - name: Install dependencies
       run: |
         brew install cmake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ allow-dict-calls-with-keyword-arguments = true
 
 [tool.cibuildwheel]
 # We need to build wheels for the following Python versions:
-build = "cp{38,39,310,311}-*"
+build = "cp{38,39,310,311,312}-*"
 
 [tool.cibuildwheel.linux]
 # Only manylinux is supported (no musllinux)
-build = "cp{38,39,310,311}-manylinux*"
+build = "cp{38,39,310,311,312}-manylinux*"
 
 # We need to clean up the build directory, all .so files, and CMakeCache.txt
 # and install the dependencies using yum, as manylinux2014 image is CentOS 7-based

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 #
 import os
 import pathlib
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -43,7 +44,7 @@ class CMakeBuild(build_ext.build_ext):
         os.makedirs(self.build_temp, exist_ok=True)
         build_type = "Debug" if self.debug else "Release"
 
-        generator = "Ninja" if subprocess.run("ninja") else "Unix Makefiles"
+        generator = "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
         use_seeding = os.environ.get("USE_SEEDING", "ON")
         use_seeding = {"1": "ON", "0": "OFF"}.get(use_seeding, use_seeding.upper())

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ import os
 import pathlib
 import subprocess
 import sys
-from distutils import spawn
-from distutils import sysconfig
+import sysconfig
 
 import setuptools
 from setuptools.command import build_ext
@@ -44,7 +43,7 @@ class CMakeBuild(build_ext.build_ext):
         os.makedirs(self.build_temp, exist_ok=True)
         build_type = "Debug" if self.debug else "Release"
 
-        generator = "Ninja" if spawn.find_executable("ninja") else "Unix Makefiles"
+        generator = "Ninja" if subprocess.run("ninja") else "Unix Makefiles"
 
         use_seeding = os.environ.get("USE_SEEDING", "ON")
         use_seeding = {"1": "ON", "0": "OFF"}.get(use_seeding, use_seeding.upper())

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class CMakeBuild(build_ext.build_ext):
             "-DCMAKE_INSTALL_PREFIX=%s" % sys.base_prefix,
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=%s" % output_path,
             "-DHACKDIR=%s" % hackdir_path,
-            "-DPYTHON_INCLUDE_DIR=%s" % sysconfig.get_python_inc(),
+            "-DPYTHON_INCLUDE_DIR=%s" % sysconfig.get_paths()["include"],
             "-DPYTHON_LIBRARY=%s" % sysconfig.get_config_var("LIBDIR"),
             "-DUSE_SEEDING=%s" % use_seeding,
         ]

--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Programming Language :: C",
             "Programming Language :: C++",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
Gymnasium v1.0.0 supports Python 3.12, so this PR adds that Python version to the test matrix & includes a wheel on release build.