### PR TITLE
Account for WIN_MESSAGE == WIN_ERR in free_window_info

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -1559,7 +1559,8 @@ boolean free_data;
     int i;
 
     if (cw->data) {
-        if (cw == wins[WIN_MESSAGE] && cw->rows > cw->maxrow)
+        if (WIN_MESSAGE != WIN_ERR && cw == wins[WIN_MESSAGE]
+            && cw->rows > cw->maxrow)
             cw->maxrow = cw->rows; /* topl data */
         for (i = 0; i < cw->maxrow; i++)
             if (cw->data[i]) {


### PR DESCRIPTION
In fact, it is always WIN_ERR in the caller in line 1403

This tripped UBSan's bounds checks