### PR TITLE
Seeding for generating levels

### DIFF
--- a/include/nledl.h
+++ b/include/nledl.h
@@ -24,6 +24,6 @@ void nle_reset(nledl_ctx *, nle_obs *, FILE *, nle_settings *);
 void nle_end(nledl_ctx *);
 
 void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, char, unsigned long);
-void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, char *, unsigned long *);
+void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, char *, unsigned long *, bool *);
 
 #endif /* NLEDL_H */

--- a/include/nledl.h
+++ b/include/nledl.h
@@ -23,7 +23,7 @@ nledl_ctx *nle_step(nledl_ctx *, nle_obs *);
 void nle_reset(nledl_ctx *, nle_obs *, FILE *, nle_settings *);
 void nle_end(nledl_ctx *);
 
-void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, char);
-void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, char *);
+void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, unsigned long, char);
+void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, unsigned long *, char *);
 
 #endif /* NLEDL_H */

--- a/include/nledl.h
+++ b/include/nledl.h
@@ -23,7 +23,7 @@ nledl_ctx *nle_step(nledl_ctx *, nle_obs *);
 void nle_reset(nledl_ctx *, nle_obs *, FILE *, nle_settings *);
 void nle_end(nledl_ctx *);
 
-void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, unsigned long, char);
-void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, unsigned long *, char *);
+void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, char, unsigned long);
+void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, char *, unsigned long *);
 
 #endif /* NLEDL_H */

--- a/include/nledl.h
+++ b/include/nledl.h
@@ -23,7 +23,9 @@ nledl_ctx *nle_step(nledl_ctx *, nle_obs *);
 void nle_reset(nledl_ctx *, nle_obs *, FILE *, nle_settings *);
 void nle_end(nledl_ctx *);
 
-void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, char, unsigned long);
-void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, char *, unsigned long *, bool *);
+void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, char,
+                  unsigned long);
+void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, char *,
+                  unsigned long *, bool *);
 
 #endif /* NLEDL_H */

--- a/include/nlernd.h
+++ b/include/nlernd.h
@@ -13,7 +13,9 @@ void nle_init_lgen_rng();
 void nle_swap_to_lgen(void);
 void nle_swap_to_core(void);
 
-void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, boolean, unsigned long);
-void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, boolean *, unsigned long *, bool *);
+void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, boolean,
+                  unsigned long);
+void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, boolean *,
+                  unsigned long *, bool *);
 
 #endif

--- a/include/nlernd.h
+++ b/include/nlernd.h
@@ -10,8 +10,8 @@ Set of functions to manipulate NetHack's Random Number Generators
 #include "nletypes.h"
 
 void nle_init_lgen_rng();
-void nle_swap_to_lgen(void);
-void nle_swap_to_core(void);
+void nle_swap_to_lgen(int);
+void nle_swap_to_core(int);
 
 void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, boolean,
                   unsigned long);

--- a/include/nlernd.h
+++ b/include/nlernd.h
@@ -9,6 +9,10 @@ Set of functions to manipulate NetHack's Random Number Generators
 
 #include "nletypes.h"
 
+void init_lgen_state(unsigned long);
+void nle_swap_to_lgen(void);
+void nle_swap_to_core(void);
+
 void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, boolean);
 void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, boolean *);
 

--- a/include/nlernd.h
+++ b/include/nlernd.h
@@ -13,7 +13,7 @@ void nle_init_lgen_rng();
 void nle_swap_to_lgen(void);
 void nle_swap_to_core(void);
 
-void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, unsigned long, boolean);
-void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, unsigned long *, boolean *);
+void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, boolean, unsigned long);
+void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, boolean *, unsigned long *);
 
 #endif

--- a/include/nlernd.h
+++ b/include/nlernd.h
@@ -9,7 +9,7 @@ Set of functions to manipulate NetHack's Random Number Generators
 
 #include "nletypes.h"
 
-void init_lgen_state(unsigned long);
+void nle_init_lgen_state();
 void nle_swap_to_lgen(void);
 void nle_swap_to_core(void);
 

--- a/include/nlernd.h
+++ b/include/nlernd.h
@@ -14,6 +14,6 @@ void nle_swap_to_lgen(void);
 void nle_swap_to_core(void);
 
 void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, boolean, unsigned long);
-void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, boolean *, unsigned long *);
+void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, boolean *, unsigned long *, bool *);
 
 #endif

--- a/include/nlernd.h
+++ b/include/nlernd.h
@@ -9,11 +9,11 @@ Set of functions to manipulate NetHack's Random Number Generators
 
 #include "nletypes.h"
 
-void nle_init_lgen_state();
+void nle_init_lgen_rng();
 void nle_swap_to_lgen(void);
 void nle_swap_to_core(void);
 
-void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, boolean);
-void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, boolean *);
+void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, unsigned long, boolean);
+void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, unsigned long *, boolean *);
 
 #endif

--- a/include/nletypes.h
+++ b/include/nletypes.h
@@ -89,6 +89,8 @@ typedef struct {
     unsigned long seeds[2]; /* core, disp */
     char reseed; /* boolean: use NetHack's anti-TAS reseed mechanism? */
     bool use_init_seeds; /* bool to tell NLE if seeds were provided */
+    unsigned long lgen_seed; /* seed for level generation RNG */
+    bool use_lgen_seed; /* bool to tell NLE to use level generation RNG */
 } nle_seeds_init_t;
 
 typedef struct nle_globals {

--- a/include/nletypes.h
+++ b/include/nletypes.h
@@ -88,7 +88,7 @@ typedef struct nle_observation {
 typedef struct {
     unsigned long seeds[2]; /* core, disp */
     char reseed; /* boolean: use NetHack's anti-TAS reseed mechanism? */
-    bool use_init_seeds; /* bool to tell NLE if seeds were provided */
+    bool use_init_seeds;     /* bool to tell NLE if seeds were provided */
     unsigned long lgen_seed; /* seed for level generation RNG */
     bool use_lgen_seed; /* bool to tell NLE to use level generation RNG */
 } nle_seeds_init_t;

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -465,7 +465,7 @@ class NLE(gym.Env):
         self._close_nethack()
         super().close()
 
-    def seed(self, core=None, disp=None, reseed=False):
+    def seed(self, core=None, disp=None, reseed=False, lgen=None):
         """Sets the state of the NetHack RNGs after the next reset.
 
         NetHack 3.6 uses two RNGs, core and disp. This is to prevent
@@ -473,6 +473,10 @@ class NLE(gym.Env):
         actual game state. This is a measure against "tool-assisted
         speedruns" (TAS). NLE can run in both NetHack's default mode and in
         TAS-friendly "no reseeding" if `reseed` is set to False, see below.
+
+        lgen allows the user to use a different RNG to generate the levels in
+        NetHack so that the levels become fixed and independent from the in-game
+        choices.
 
         Arguments:
             core [int or None]: Seed for the core RNG. If None, chose a random
@@ -483,6 +487,8 @@ class NLE(gym.Env):
                 NetHack 3.6 reseeds with true randomness every now and then. This
                 flag enables or disables this behavior. If set to True, trajectories
                 won't be reproducible.
+            lgen [int or None]: Seed for the level generator, used for RNG when
+                NetHack generates new levels.
 
         Returns:
             [tuple] The seeds supplied, in the form (core, disp, reseed).
@@ -491,7 +497,7 @@ class NLE(gym.Env):
             core = self._random.randrange(sys.maxsize)
         if disp is None:
             disp = self._random.randrange(sys.maxsize)
-        self.nethack.set_initial_seeds(core, disp, reseed)
+        self.nethack.set_initial_seeds(core, disp, reseed, lgen)
         return (core, disp, reseed)
 
     def get_seeds(self):

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -498,7 +498,7 @@ class NLE(gym.Env):
         if disp is None:
             disp = self._random.randrange(sys.maxsize)
         self.nethack.set_initial_seeds(core, disp, reseed, lgen)
-        return (core, disp, reseed)
+        return (core, disp, reseed, lgen)
 
     def get_seeds(self):
         """Returns current seeds.

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -491,10 +491,7 @@ class NLE(gym.Env):
                 NetHack generates new levels.
 
         Returns:
-            [tuple] The seeds supplied, in the form (core, disp, reseed).
-            or
-            [tuple] The seeds including the lgen seed if passed (core, disp,
-                    reseed, lgen)
+            [tuple] The seeds supplied, in the form (core, disp, reseed, lgen).
         """
         if core is None:
             core = self._random.randrange(sys.maxsize)

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -497,14 +497,16 @@ class NLE(gym.Env):
             core = self._random.randrange(sys.maxsize)
         if disp is None:
             disp = self._random.randrange(sys.maxsize)
-        self.nethack.set_initial_seeds(core, disp, reseed, lgen)
-        return (core, disp, reseed, lgen)
+        if lgen is None:
+            lgen = self._random.randrange(sys.maxsize)
+        self.nethack.set_initial_seeds(core, disp, lgen, reseed)
+        return (core, disp, lgen, reseed)
 
     def get_seeds(self):
         """Returns current seeds.
 
         Returns:
-            (tuple): Current NetHack (core, disp, reseed) state.
+            (tuple): Current NetHack (core, disp, reseed, lgen) state.
         """
         return self.nethack.get_current_seeds()
 

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -492,21 +492,28 @@ class NLE(gym.Env):
 
         Returns:
             [tuple] The seeds supplied, in the form (core, disp, reseed).
+            or
+            [tuple] The seeds including the lgen seed if passed (core, disp,
+                    reseed, lgen)
         """
         if core is None:
             core = self._random.randrange(sys.maxsize)
         if disp is None:
             disp = self._random.randrange(sys.maxsize)
+        self.nethack.set_initial_seeds(core, disp, reseed, lgen)
         if lgen is None:
-            lgen = self._random.randrange(sys.maxsize)
-        self.nethack.set_initial_seeds(core, disp, lgen, reseed)
-        return (core, disp, lgen, reseed)
+            result = (core, disp, reseed)
+        else:
+            result = (core, disp, reseed, lgen)
+        return result
 
     def get_seeds(self):
         """Returns current seeds.
 
         Returns:
-            (tuple): Current NetHack (core, disp, reseed, lgen) state.
+            (tuple): Current NetHack (core, disp, reseed) state.
+            or
+            (tuple): Current NetHack seeds and lgen if previously set.
         """
         return self.nethack.get_current_seeds()
 

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -501,19 +501,13 @@ class NLE(gym.Env):
         if disp is None:
             disp = self._random.randrange(sys.maxsize)
         self.nethack.set_initial_seeds(core, disp, reseed, lgen)
-        if lgen is None:
-            result = (core, disp, reseed)
-        else:
-            result = (core, disp, reseed, lgen)
-        return result
+        return (core, disp, reseed, lgen)
 
     def get_seeds(self):
         """Returns current seeds.
 
         Returns:
-            (tuple): Current NetHack (core, disp, reseed) state.
-            or
-            (tuple): Current NetHack seeds and lgen if previously set.
+            (tuple): Current NetHack (core, disp, reseed, lgen) state.
         """
         return self.nethack.get_current_seeds()
 

--- a/nle/env/tasks.py
+++ b/nle/env/tasks.py
@@ -368,5 +368,5 @@ class NetHackChallenge(NetHackScore):
             or self._no_progress_count >= self.no_progress_timeout
         )
 
-    def seed(self, core=None, disp=None, reseed=True):
+    def seed(self, core=None, disp=None, reseed=True, lgen=None):
         raise RuntimeError("NetHackChallenge doesn't allow seed changes")

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -281,12 +281,9 @@ class Nethack:
         self._tempdir = None
 
     def set_initial_seeds(self, core, disp, reseed=False, lgen=None):
-        if lgen is None:
-            self._pynethack.set_initial_seeds(core, disp, reseed, 0, False)
-        else:
-            self._pynethack.set_initial_seeds(core, disp, reseed, lgen, True)
+        self._pynethack.set_initial_seeds(core, disp, reseed, lgen)
 
-    def set_current_seeds(self, core=None, disp=None, reseed=False, lgen=False):
+    def set_current_seeds(self, core=None, disp=None, reseed=False, lgen=None):
         """Sets the seeds of NetHack right now.
 
         If either of the three arguments is None, its current value will be
@@ -320,10 +317,7 @@ class Nethack:
         return self._pynethack.set_seeds(core, disp, reseed, lgen)
 
     def get_current_seeds(self):
-        seeds = self._pynethack.get_seeds()
-        if seeds[3] == 0:
-            seeds = seeds[:3]
-        return seeds
+        return self._pynethack.get_seeds()
 
     def in_normal_game(self):
         return self._pynethack.in_normal_game()

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -280,8 +280,11 @@ class Nethack:
         self._dl = None
         self._tempdir = None
 
-    def set_initial_seeds(self, core, disp, reseed=False):
-        self._pynethack.set_initial_seeds(core, disp, reseed)
+    def set_initial_seeds(self, core, disp, reseed=False, lgen=None):
+        if lgen is None:
+            self._pynethack.set_initial_seeds(core, disp, reseed)
+        else:
+            self._pynethack.set_initial_seeds(core, disp, reseed, lgen)
 
     def set_current_seeds(self, core=None, disp=None, reseed=False):
         """Sets the seeds of NetHack right now.

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -280,13 +280,10 @@ class Nethack:
         self._dl = None
         self._tempdir = None
 
-    def set_initial_seeds(self, core, disp, reseed=False, lgen=None):
-        if lgen is None:
-            self._pynethack.set_initial_seeds(core, disp, reseed)
-        else:
-            self._pynethack.set_initial_seeds(core, disp, reseed, lgen)
+    def set_initial_seeds(self, core, disp, lgen, reseed=False):
+        self._pynethack.set_initial_seeds(core, disp, lgen, reseed)
 
-    def set_current_seeds(self, core=None, disp=None, reseed=False):
+    def set_current_seeds(self, core=None, disp=None, reseed=False, lgen=False):
         """Sets the seeds of NetHack right now.
 
         If either of the three arguments is None, its current value will be
@@ -304,11 +301,12 @@ class Nethack:
                 NetHack 3.6 reseeds with true randomness every now and then. This
                 flag enables or disables this behavior. If set to True, trajectories
                 won't be reproducible.
+            lgen [int or None]: Special NLE RNG for generating levels
 
         Returns:
             [list] the seeds used by NetHack.
         """
-        seeds = [core, disp, reseed]
+        seeds = [core, disp, reseed, lgen]
         if any(s is None for s in seeds):
             if all(s is None for s in seeds):
                 return None
@@ -316,7 +314,7 @@ class Nethack:
                 if s is None:
                     seeds[i] = s0
             return self._pynethack.set_seeds(*seeds)
-        return self._pynethack.set_seeds(core, disp, reseed)
+        return self._pynethack.set_seeds(core, disp, reseed, lgen)
 
     def get_current_seeds(self):
         return self._pynethack.get_seeds()

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -124,13 +124,13 @@ def tty_render(chars, colors, cursor=None):
     """Returns chars as string with ANSI escape sequences.
 
     Args:
-      chars: A row x columns numpy array of chars.
-      colors: A numpy array of colors (0-15), same shape as chars.
-      cursor: An optional (row, column) index for the cursor,
+    chars: A row x columns numpy array of chars.
+    colors: A numpy array of colors (0-15), same shape as chars.
+    cursor: An optional (row, column) index for the cursor,
         displayed as underlined.
 
     Returns:
-      A string with chars decorated by ANSI escape sequences.
+    A string with chars decorated by ANSI escape sequences.
     """
     rows, cols = chars.shape
     if cursor is None:
@@ -280,8 +280,11 @@ class Nethack:
         self._dl = None
         self._tempdir = None
 
-    def set_initial_seeds(self, core, disp, lgen, reseed=False):
-        self._pynethack.set_initial_seeds(core, disp, lgen, reseed)
+    def set_initial_seeds(self, core, disp, reseed=False, lgen=None):
+        if lgen is None:
+            self._pynethack.set_initial_seeds(core, disp, reseed, 0, False)
+        else:
+            self._pynethack.set_initial_seeds(core, disp, reseed, lgen, True)
 
     def set_current_seeds(self, core=None, disp=None, reseed=False, lgen=False):
         """Sets the seeds of NetHack right now.
@@ -317,7 +320,10 @@ class Nethack:
         return self._pynethack.set_seeds(core, disp, reseed, lgen)
 
     def get_current_seeds(self):
-        return self._pynethack.get_seeds()
+        seeds = self._pynethack.get_seeds()
+        if seeds[3] == 0:
+            seeds = seeds[:3]
+        return seeds
 
     def in_normal_game(self):
         return self._pynethack.in_normal_game()

--- a/nle/scripts/play.py
+++ b/nle/scripts/play.py
@@ -95,7 +95,7 @@ def play():
             render_mode=FLAGS.render_mode,
         )
         if FLAGS.seeds is not None:
-            env.unwrapped.seed(FLAGS.seeds)
+            env.unwrapped.seed(*FLAGS.seeds)
 
     obs, reset_info = env.reset()
 

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -323,6 +323,54 @@ class TestGymEnvRollout:
         np.testing.assert_equal(obs0, obs1)
         compare_rollouts(env0, env1, rollout_len)
 
+    def test_seed_lgen(self, env_name, rollout_len):
+        """Tests that the lgen seed returns deterministic dungeon structure"""
+        if env_name.startswith("NetHackChallenge"):
+            pytest.skip("Not running seed test on NetHackChallenge")
+
+        env = gym.make(env_name)
+        env.unwrapped.seed(lgen=1)
+        obs = env.reset()
+
+        assert env.unwrapped.get_seeds()[3] == 1
+
+        # check for the first room the agent appears.
+        # note: even with level generation, some aspects
+        # of the contents of the rooms are random
+        assert obs[0]["chars"][15][1] == ord("-")
+        assert obs[0]["chars"][16][6] == ord(".")
+        assert obs[0]["chars"][16][10] == ord(".")
+        assert obs[0]["chars"][18][10] == ord("+")
+
+    def test_seeds_with_lgen(self, env_name, rollout_len):
+        """Tests that the lgen seed returns deterministic dungeon structure,
+        when passed alongside other NetHack seed values"""
+        if env_name.startswith("NetHackChallenge"):
+            pytest.skip("Not running seed test on NetHackChallenge")
+
+        env = gym.make(env_name)
+        env.unwrapped.seed(1234, 5678, False, 1)
+        obs = env.reset()
+
+        assert env.unwrapped.get_seeds()[3] == 1
+
+        # check for the first room the agent appears.
+        # note: even with level generation, some aspects
+        # of the contents of the rooms are random
+        assert obs[0]["chars"][15][1] == ord("-")
+        assert obs[0]["chars"][16][6] == ord(".")
+        assert obs[0]["chars"][16][10] == ord(".")
+        assert obs[0]["chars"][18][10] == ord("+")
+
+    # Further level-generation tests:
+    # There should be a test that compares level two in multiple
+    # rollouts. That requires an agent that can successfully and
+    # always find the stairs and descend to the second level. To
+    # say nothing about deeper levels of the dungeon! For now it
+    # doesn't exist, and so remains an active area of research.
+    #
+    # Left as an exercise for the student?
+
     def test_render_ansi(self, env_name, rollout_len):
         env = gym.make(env_name, render_mode="ansi")
         env.reset()

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -335,12 +335,11 @@ class TestGymEnvRollout:
         assert env.unwrapped.get_seeds()[3] == 1
 
         # check for the first room the agent appears.
-        # note: even with level generation, some aspects
-        # of the contents of the rooms are random
-        assert obs[0]["chars"][15][1] == ord("-")
-        assert obs[0]["chars"][16][6] == ord(".")
-        assert obs[0]["chars"][16][10] == ord(".")
-        assert obs[0]["chars"][18][10] == ord("+")
+        assert obs[0]["chars"][5][68] == ord("-")
+        assert obs[0]["chars"][8][69] == ord(".")
+        assert obs[0]["chars"][7][68] == ord(".")
+        assert obs[0]["chars"][7][67] == ord("+")
+        assert obs[0]["chars"][8][71] == ord("@")
 
     def test_seeds_with_lgen(self, env_name, rollout_len):
         """Tests that the lgen seed returns deterministic dungeon structure,
@@ -355,12 +354,11 @@ class TestGymEnvRollout:
         assert env.unwrapped.get_seeds()[3] == 1
 
         # check for the first room the agent appears.
-        # note: even with level generation, some aspects
-        # of the contents of the rooms are random
-        assert obs[0]["chars"][15][1] == ord("-")
-        assert obs[0]["chars"][16][6] == ord(".")
-        assert obs[0]["chars"][16][10] == ord(".")
-        assert obs[0]["chars"][18][10] == ord("+")
+        assert obs[0]["chars"][5][68] == ord("-")
+        assert obs[0]["chars"][8][69] == ord(".")
+        assert obs[0]["chars"][7][68] == ord(".")
+        assert obs[0]["chars"][7][67] == ord("+")
+        assert obs[0]["chars"][8][71] == ord("@")
 
     # Further level-generation tests:
     # There should be a test that compares level two in multiple

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -335,11 +335,11 @@ class TestGymEnvRollout:
         assert env.unwrapped.get_seeds()[3] == 1
 
         # check for the first room the agent appears.
-        assert obs[0]["chars"][5][68] == ord("-")
-        assert obs[0]["chars"][8][69] == ord(".")
-        assert obs[0]["chars"][7][68] == ord(".")
-        assert obs[0]["chars"][7][67] == ord("+")
-        assert obs[0]["chars"][8][71] == ord("@")
+        assert obs[0]["chars"][3][61] == ord("-")
+        assert obs[0]["chars"][4][51] == ord(".")
+        assert obs[0]["chars"][5][59] == ord(".")
+        assert obs[0]["chars"][7][59] == ord("+")
+        assert obs[0]["chars"][7][51] == ord("@")
 
     def test_seeds_with_lgen(self, env_name, rollout_len):
         """Tests that the lgen seed returns deterministic dungeon structure,
@@ -354,11 +354,11 @@ class TestGymEnvRollout:
         assert env.unwrapped.get_seeds()[3] == 1
 
         # check for the first room the agent appears.
-        assert obs[0]["chars"][5][68] == ord("-")
-        assert obs[0]["chars"][8][69] == ord(".")
-        assert obs[0]["chars"][7][68] == ord(".")
-        assert obs[0]["chars"][7][67] == ord("+")
-        assert obs[0]["chars"][8][71] == ord("@")
+        assert obs[0]["chars"][3][61] == ord("-")
+        assert obs[0]["chars"][4][51] == ord(".")
+        assert obs[0]["chars"][5][59] == ord(".")
+        assert obs[0]["chars"][7][59] == ord("+")
+        assert obs[0]["chars"][7][51] == ord("@")
 
     # Further level-generation tests:
     # There should be a test that compares level two in multiple

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -285,7 +285,7 @@ class TestGymEnvRollout:
         obs0 = env0.reset()
         seeds0 = env0.unwrapped.get_seeds()
 
-        assert seeds0 == (123456, 789012, False)
+        assert seeds0 == (123456, 789012, False, None)
 
         env1.unwrapped.seed(*seeds0)
         obs1 = env1.reset()
@@ -308,6 +308,7 @@ class TestGymEnvRollout:
             random.randrange(sys.maxsize),
             random.randrange(sys.maxsize),
             False,
+            random.randrange(sys.maxsize),
         )
         env0.unwrapped.seed(*initial_seeds)
         obs0 = env0.reset()

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -357,7 +357,7 @@ class TestGymEnvRollout:
         assert obs[0]["chars"][3][61] == ord("-")
         assert obs[0]["chars"][4][51] == ord(".")
         assert obs[0]["chars"][5][59] == ord(".")
-        assert obs[0]["chars"][7][59] == ord("+")
+        assert obs[0]["chars"][7][65] == ord("|")
         assert obs[0]["chars"][7][51] == ord("@")
 
     # Further level-generation tests:

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -338,7 +338,7 @@ class TestGymEnvRollout:
         assert obs[0]["chars"][3][61] == ord("-")
         assert obs[0]["chars"][4][51] == ord(".")
         assert obs[0]["chars"][5][59] == ord(".")
-        assert obs[0]["chars"][7][59] == ord("+")
+        assert obs[0]["chars"][7][65] == ord("|")
         assert obs[0]["chars"][7][51] == ord("@")
 
     def test_seeds_with_lgen(self, env_name, rollout_len):

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -137,7 +137,7 @@ class TestNetHack:
         # Could fail on a system without a good source of randomness:
         assert game.get_current_seeds()[2] is True
         game.set_current_seeds(core=42, disp=666)
-        assert game.get_current_seeds() == (42, 666, False)
+        assert game.get_current_seeds() == (42, 666, False, 0)
 
 
 class TestNetHackFurther:

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,6 @@
 #  HACKDIR
 #    If set, install NetHack's data files in this directory.
 #
-#  USE_SEEDING
-#    If set, seeding is disabled in all NLE environments.
-#
 import os
 import pathlib
 import shutil
@@ -46,9 +43,6 @@ class CMakeBuild(build_ext.build_ext):
 
         generator = "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
-        use_seeding = os.environ.get("USE_SEEDING", "ON")
-        use_seeding = {"1": "ON", "0": "OFF"}.get(use_seeding, use_seeding.upper())
-
         cmake_cmd = [
             "cmake",
             str(source_path),
@@ -62,7 +56,6 @@ class CMakeBuild(build_ext.build_ext):
             "-DHACKDIR=%s" % hackdir_path,
             "-DPYTHON_INCLUDE_DIR=%s" % sysconfig.get_paths()["include"],
             "-DPYTHON_LIBRARY=%s" % sysconfig.get_config_var("LIBDIR"),
-            "-DUSE_SEEDING=%s" % use_seeding,
         ]
 
         build_cmd = ["cmake", "--build", ".", "--parallel"]

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -26,8 +26,8 @@ STATIC_DCL void FDECL(debug_fields, (const char *));
 extern int FDECL(nle_spawn_monsters, ());
 
 /* NLE RNG selection functions */
-extern void FDECL(nle_swap_to_lgen, ());
-extern void FDECL(nle_swap_to_core, ());
+extern void FDECL(nle_swap_to_lgen, (int));
+extern void FDECL(nle_swap_to_core, (int));
 
 void
 moveloop(resuming)
@@ -606,7 +606,7 @@ newgame()
         mvitals[i].mvflags = mons[i].geno & G_NOCORPSE;
 
     /* Use lgen for game / dungeon initialisation */
-    nle_swap_to_lgen();
+    nle_swap_to_lgen(0);
 
     init_objects(); /* must be before u_init() */
 
@@ -659,7 +659,7 @@ newgame()
     welcome(TRUE);
 
     /* Restore CORE RNG */
-    nle_swap_to_core();
+    nle_swap_to_core(0);
 
     return;
 }

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -25,6 +25,10 @@ STATIC_DCL void FDECL(debug_fields, (const char *));
  */
 extern int FDECL(nle_spawn_monsters, ());
 
+/* NLE RNG selection functions */
+extern void FDECL(nle_swap_to_lgen, ());
+extern void FDECL(nle_swap_to_core, ());
+
 void
 moveloop(resuming)
 boolean resuming;
@@ -601,6 +605,9 @@ newgame()
     for (i = LOW_PM; i < NUMMONS; i++)
         mvitals[i].mvflags = mons[i].geno & G_NOCORPSE;
 
+    /* Use lgen for game / dungeon initialisation */
+    nle_swap_to_lgen();
+
     init_objects(); /* must be before u_init() */
 
     flags.pantheon = -1; /* role_init() will reset this */
@@ -650,6 +657,10 @@ newgame()
 
     /* Success! */
     welcome(TRUE);
+
+    /* Restore CORE RNG */
+    nle_swap_to_core();
+
     return;
 }
 

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -851,8 +851,9 @@ extern struct tm *FDECL(localtime, (time_t *));
 #endif
 STATIC_DCL struct tm *NDECL(getlt);
 
-/* NLE hack for seeds. Should stay in sync with rnglist in src/rnd.c. */
-unsigned long nle_seeds[] = {0L, 0L};
+/* NLE hack for seeds. Should stay in sync with rnglist in src/rnd.c.
+   plus one other RNG seed for level generation. See nlernd.c */
+extern unsigned long nle_seeds[];
 extern int FDECL(whichrng, (int FDECL((*fn), (int))));
 
 /* Sets the seed for the random number generator */

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -5,6 +5,9 @@
 
 #include "hack.h"
 
+/* NLE RNG modifiers */
+#include "nlernd.h"
+
 /* for UNIX, Rand #def'd to (long)lrand48() or (long)random() */
 /* croom->lx etc are schar (width <= int), so % arith ensures that */
 /* conversion of result to int is reasonable */
@@ -996,6 +999,9 @@ mklev()
     reseed_random(rn2);
     reseed_random(rn2_on_display_rng);
 
+    /* NLE: Use the level generation RNG if required */
+    nle_swap_to_lgen();
+
     init_mapseen(&u.uz);
     if (getbones())
         return;
@@ -1030,6 +1036,9 @@ mklev()
        now so that they never do and no one will be tempted to introduce
        a new use of them for anything on this level */
     dnstairs_room = upstairs_room = sstairs_room = (struct mkroom *) 0;
+
+    /* NLE: Restore CORE RNG state if required */
+    nle_swap_to_core();
 
     reseed_random(rn2);
     reseed_random(rn2_on_display_rng);

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -1000,7 +1000,7 @@ mklev()
     reseed_random(rn2_on_display_rng);
 
     /* NLE: Use the level generation RNG if required */
-    nle_swap_to_lgen();
+    nle_swap_to_lgen(u.uz.dnum);
 
     init_mapseen(&u.uz);
     if (getbones())
@@ -1038,7 +1038,7 @@ mklev()
     dnstairs_room = upstairs_room = sstairs_room = (struct mkroom *) 0;
 
     /* NLE: Restore CORE RNG state if required */
-    nle_swap_to_core();
+    nle_swap_to_core(u.uz.dnum);
 
     reseed_random(rn2);
     reseed_random(rn2_on_display_rng);

--- a/src/nle.c
+++ b/src/nle.c
@@ -399,6 +399,11 @@ nle_start(nle_obs *obs, FILE *ttyrec, nle_settings *settings_p)
 
     nle_ctx_t *nle = init_nle(ttyrec, obs);
 
+    /* if there's a level generation seed, then initialise the RNG */
+    if(settings.initial_seeds.use_lgen_seed) {
+        init_lgen_state(settings.initial_seeds.lgen_seed);
+    }
+
     nle->stack = create_fcontext_stack(STACK_SIZE);
     nle->generatorcontext =
         make_fcontext(nle->stack.sptr, nle->stack.ssize, mainloop);

--- a/src/nle.c
+++ b/src/nle.c
@@ -399,8 +399,8 @@ nle_start(nle_obs *obs, FILE *ttyrec, nle_settings *settings_p)
 
     nle_ctx_t *nle = init_nle(ttyrec, obs);
 
-    /* Initialise the state and control flag of our own RNG */
-    nle_init_lgen_state();
+    /* Initialise the level generation RNG */
+    nle_init_lgen_rng();
 
     nle->stack = create_fcontext_stack(STACK_SIZE);
     nle->generatorcontext =

--- a/src/nle.c
+++ b/src/nle.c
@@ -399,10 +399,8 @@ nle_start(nle_obs *obs, FILE *ttyrec, nle_settings *settings_p)
 
     nle_ctx_t *nle = init_nle(ttyrec, obs);
 
-    /* if there's a level generation seed, then initialise the RNG */
-    if(settings.initial_seeds.use_lgen_seed) {
-        init_lgen_state(settings.initial_seeds.lgen_seed);
-    }
+    /* Initialise the state and control flag of our own RNG */
+    nle_init_lgen_state();
 
     nle->stack = create_fcontext_stack(STACK_SIZE);
     nle->generatorcontext =

--- a/src/nlernd.c
+++ b/src/nlernd.c
@@ -4,7 +4,7 @@
 
 /* See rng.c. */
 struct rnglist_t {
-    int FDECL((*fn), (int));
+    int FDECL((*fn), (int) );
     boolean init;
     isaac64_ctx rng_state;
 };
@@ -37,15 +37,20 @@ init_random(int FDECL((*fn), (int) ))
     }
 }
 
-unsigned long nle_seeds[] = {0L, 0L, 0L};
+unsigned long nle_seeds[] = { 0L, 0L, 0L };
 
-static struct isaac64_ctx nle_lgen_state; /* State of the level generation RNG */
-static struct isaac64_ctx nle_core_state; /* State of the core RNG */
+/* State of the level generation RNG */
+static struct isaac64_ctx nle_lgen_state;
+
+/* State of the core RNG */
+static struct isaac64_ctx nle_core_state;
+
 static bool lgen_initialised = false;
 
 /* Seeding function to initialise the fixed-level rng state.
    Borrowed from init_isaac64 in NetHack's rnd.c */
-void nle_init_lgen_state(unsigned long seed)
+void
+nle_init_lgen_state(unsigned long seed)
 {
     unsigned char new_rng_state[sizeof seed];
     unsigned i;
@@ -55,13 +60,13 @@ void nle_init_lgen_state(unsigned long seed)
         seed >>= 8;
     }
 
-    isaac64_init(&nle_lgen_state, new_rng_state,
-                (int) sizeof seed);
+    isaac64_init(&nle_lgen_state, new_rng_state, (int) sizeof seed);
 }
 
-void nle_init_lgen_rng()
+void
+nle_init_lgen_rng()
 {
-    if(settings.initial_seeds.use_lgen_seed) {
+    if (settings.initial_seeds.use_lgen_seed) {
         nle_init_lgen_state(settings.initial_seeds.lgen_seed);
         lgen_initialised = true;
     } else {
@@ -71,22 +76,24 @@ void nle_init_lgen_rng()
     nle_seeds[2] = settings.initial_seeds.lgen_seed;
 }
 
-void nle_swap_to_lgen(void)
+void
+nle_swap_to_lgen(void)
 {
-    if(lgen_initialised) {
+    if (lgen_initialised) {
         int core_rng = whichrng(rn2);
 
         /* stash the current core state */
         nle_core_state = rnglist[core_rng].rng_state;
-    
+
         /* copy the current lgen state */
-        rnglist[core_rng].rng_state = nle_lgen_state;        
+        rnglist[core_rng].rng_state = nle_lgen_state;
     }
 }
 
-void nle_swap_to_core(void)
+void
+nle_swap_to_core(void)
 {
-    if(lgen_initialised) {
+    if (lgen_initialised) {
         int core_rng = whichrng(rn2);
 
         /* stash the current lgen state */
@@ -99,7 +106,7 @@ void nle_swap_to_core(void)
 
 void
 nle_set_seed(nle_ctx_t *nle, unsigned long core, unsigned long disp,
-    boolean reseed, unsigned long lgen)
+             boolean reseed, unsigned long lgen)
 {
     /* Keep up to date with rnglist[] in rnd.c. */
     set_random(core, rn2);
@@ -115,7 +122,7 @@ nle_set_seed(nle_ctx_t *nle, unsigned long core, unsigned long disp,
 
 void
 nle_get_seed(nle_ctx_t *nle, unsigned long *core, unsigned long *disp,
-    boolean *reseed, unsigned long *lgen, bool *lgen_in_use)
+             boolean *reseed, unsigned long *lgen, bool *lgen_in_use)
 {
     *core = nle_seeds[0];
     *disp = nle_seeds[1];

--- a/src/nlernd.c
+++ b/src/nlernd.c
@@ -115,10 +115,11 @@ nle_set_seed(nle_ctx_t *nle, unsigned long core, unsigned long disp,
 
 void
 nle_get_seed(nle_ctx_t *nle, unsigned long *core, unsigned long *disp,
-    boolean *reseed, unsigned long *lgen)
+    boolean *reseed, unsigned long *lgen, bool *lgen_in_use)
 {
     *core = nle_seeds[0];
     *disp = nle_seeds[1];
     *reseed = has_strong_rngseed;
     *lgen = nle_seeds[2];
+    *lgen_in_use = lgen_initialised;
 }

--- a/src/nlernd.c
+++ b/src/nlernd.c
@@ -43,20 +43,27 @@ static bool lgen_initialised = false;
 
 /* Seeding function to initialise the fixed-level rng.
    Borrowed from init_isaac64 in NetHack's rnd.c */
-void init_lgen_state(unsigned long seed)
+void nle_init_lgen_state()
 {
-    unsigned char new_rng_state[sizeof seed];
-    unsigned i;
+    if(settings.initial_seeds.use_lgen_seed) {
 
-    for (i = 0; i < sizeof seed; i++) {
-        new_rng_state[i] = (unsigned char) (seed & 0xFF);
-        seed >>= 8;
+        unsigned long seed = settings.initial_seeds.lgen_seed;
+
+        unsigned char new_rng_state[sizeof seed];
+        unsigned i;
+
+        for (i = 0; i < sizeof seed; i++) {
+            new_rng_state[i] = (unsigned char) (seed & 0xFF);
+            seed >>= 8;
+        }
+
+        isaac64_init(&nle_lgen_state, new_rng_state,
+                    (int) sizeof seed);
+
+        lgen_initialised = true;
+    } else {
+        lgen_initialised = false; 
     }
-
-    isaac64_init(&nle_lgen_state, new_rng_state,
-                 (int) sizeof seed);
-
-    lgen_initialised = true;
 }
 
 void nle_swap_to_lgen(void)

--- a/src/nlernd.c
+++ b/src/nlernd.c
@@ -99,7 +99,7 @@ void nle_swap_to_core(void)
 
 void
 nle_set_seed(nle_ctx_t *nle, unsigned long core, unsigned long disp,
-    unsigned long lgen, boolean reseed)
+    boolean reseed, unsigned long lgen)
 {
     /* Keep up to date with rnglist[] in rnd.c. */
     set_random(core, rn2);
@@ -115,7 +115,7 @@ nle_set_seed(nle_ctx_t *nle, unsigned long core, unsigned long disp,
 
 void
 nle_get_seed(nle_ctx_t *nle, unsigned long *core, unsigned long *disp,
-    unsigned long *lgen, boolean *reseed)
+    boolean *reseed, unsigned long *lgen)
 {
     *core = nle_seeds[0];
     *disp = nle_seeds[1];

--- a/src/nlernd.c
+++ b/src/nlernd.c
@@ -39,7 +39,7 @@ init_random(int FDECL((*fn), (int) ))
 
 unsigned long nle_seeds[] = { 0L, 0L, 0L };
 
-/* We define the number of dungeons explicitly here. 
+/* We define the number of dungeons explicitly here.
    NetHack works it out from the "dungeon.def" file,
    sadly after already sampling random numbers. This
    means you have to make sure that if the number of
@@ -52,7 +52,7 @@ unsigned long nle_seeds[] = { 0L, 0L, 0L };
    for each dungeon. */
 static struct isaac64_ctx nle_lgen_base;
 
-/* RNG States for level generation, one for each dungeon */ 
+/* RNG States for level generation, one for each dungeon */
 static struct isaac64_ctx nle_lgen_state[NLE_NUM_DUNGEONS];
 
 /* State of the NetHack CORE RNG, used to remember what
@@ -85,13 +85,14 @@ void
 nle_init_lgen_rng()
 {
     if (settings.initial_seeds.use_lgen_seed) {
-        /* initialise the base state which will be used 
+        /* initialise the base state which will be used
            for seeding the RNGs for the dungeons */
         nle_init_lgen_state(settings.initial_seeds.lgen_seed, &nle_lgen_base);
 
         /* generate a new RNG for each of the dungeons */
-        for(int i = 0; i < NLE_NUM_DUNGEONS; i++)
-            nle_init_lgen_state(isaac64_next_uint64(&nle_lgen_base), &(nle_lgen_state[i]));
+        for (int i = 0; i < NLE_NUM_DUNGEONS; i++)
+            nle_init_lgen_state(isaac64_next_uint64(&nle_lgen_base),
+                                &(nle_lgen_state[i]));
 
         lgen_initialised = true;
     } else {

--- a/src/nlernd.c
+++ b/src/nlernd.c
@@ -39,20 +39,36 @@ init_random(int FDECL((*fn), (int) ))
 
 unsigned long nle_seeds[] = { 0L, 0L, 0L };
 
-/* State of the level generation RNG */
-static struct isaac64_ctx nle_lgen_state;
+/* We define the number of dungeons explicitly here. 
+   NetHack works it out from the "dungeon.def" file,
+   sadly after already sampling random numbers. This
+   means you have to make sure that if the number of
+   dungeons changes in the future then this needs to
+   be kept in sync. */
+#define NLE_NUM_DUNGEONS 8
 
-/* State of the core RNG */
+/* Base LGEN RNG state, initialised via the seed &
+   used in turn to sample seed values for the RNGs
+   for each dungeon. */
+static struct isaac64_ctx nle_lgen_base;
+
+/* RNG States for level generation, one for each dungeon */ 
+static struct isaac64_ctx nle_lgen_state[NLE_NUM_DUNGEONS];
+
+/* State of the NetHack CORE RNG, used to remember what
+   it was before we created the level and then restored
+   after the level is ready. This allows for randomness
+   during exploration / combat in-level. */
 static struct isaac64_ctx nle_core_state;
 
-/* Some flags to help  manage the lgen seed */
+/* Some flags to help manage the lgen seed */
 static bool lgen_initialised = false;
 static bool lgen_active = false;
 
-/* Seeding function to initialise the fixed-level rng state.
+/* Seeding function to initialise a fixed-level RNG state.
    Borrowed from init_isaac64 in NetHack's rnd.c */
 void
-nle_init_lgen_state(unsigned long seed)
+nle_init_lgen_state(unsigned long seed, struct isaac64_ctx *state)
 {
     unsigned char new_rng_state[sizeof seed];
     unsigned i;
@@ -62,14 +78,21 @@ nle_init_lgen_state(unsigned long seed)
         seed >>= 8;
     }
 
-    isaac64_init(&nle_lgen_state, new_rng_state, (int) sizeof seed);
+    isaac64_init(state, new_rng_state, (int) sizeof seed);
 }
 
 void
 nle_init_lgen_rng()
 {
     if (settings.initial_seeds.use_lgen_seed) {
-        nle_init_lgen_state(settings.initial_seeds.lgen_seed);
+        /* initialise the base state which will be used 
+           for seeding the RNGs for the dungeons */
+        nle_init_lgen_state(settings.initial_seeds.lgen_seed, &nle_lgen_base);
+
+        /* generate a new RNG for each of the dungeons */
+        for(int i = 0; i < NLE_NUM_DUNGEONS; i++)
+            nle_init_lgen_state(isaac64_next_uint64(&nle_lgen_base), &(nle_lgen_state[i]));
+
         lgen_initialised = true;
     } else {
         lgen_initialised = false;
@@ -79,7 +102,7 @@ nle_init_lgen_rng()
 }
 
 void
-nle_swap_to_lgen(void)
+nle_swap_to_lgen(int dungeon_num)
 {
     if (lgen_initialised && !lgen_active) {
         int core_rng = whichrng(rn2);
@@ -88,7 +111,7 @@ nle_swap_to_lgen(void)
         nle_core_state = rnglist[core_rng].rng_state;
 
         /* copy the current lgen state */
-        rnglist[core_rng].rng_state = nle_lgen_state;
+        rnglist[core_rng].rng_state = nle_lgen_state[dungeon_num];
 
         /* since we want nle_swap_to_lgen and swap_to_core to be
            called in the correct sequence we ignore subsequent
@@ -98,13 +121,13 @@ nle_swap_to_lgen(void)
 }
 
 void
-nle_swap_to_core(void)
+nle_swap_to_core(int dungeon_num)
 {
     if (lgen_initialised && lgen_active) {
         int core_rng = whichrng(rn2);
 
         /* stash the current lgen state */
-        nle_lgen_state = rnglist[core_rng].rng_state;
+        nle_lgen_state[dungeon_num] = rnglist[core_rng].rng_state;
 
         /* restore the core state */
         rnglist[core_rng].rng_state = nle_core_state;
@@ -127,7 +150,7 @@ nle_set_seed(nle_ctx_t *nle, unsigned long core, unsigned long disp,
     /* Determines logic in reseed_random() in hacklib.c. */
     has_strong_rngseed = reseed;
 
-    nle_init_lgen_state(lgen);
+    nle_init_lgen_state(lgen, &nle_lgen_base);
     lgen_initialised = true;
     nle_seeds[2] = lgen;
 };

--- a/src/rnd.c
+++ b/src/rnd.c
@@ -19,7 +19,9 @@ struct rnglist_t {
 
 enum { CORE = 0, DISP = 1 };
 
-static struct rnglist_t rnglist[] = {
+/* For NLE purposes, remove the static storage class so
+   that we can see the RNG states from our own functions. */
+struct rnglist_t rnglist[] = {
     { rn2, FALSE, { 0 } },                      /* CORE */
     { rn2_on_display_rng, FALSE, { 0 } },       /* DISP */
 };

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -113,9 +113,9 @@ nle_end(nledl_ctx *nledl)
 
 void
 nle_set_seed(nledl_ctx *nledl, unsigned long core, unsigned long disp,
-    unsigned long lgen, char reseed)
+    char reseed, unsigned long lgen)
 {
-    void (*set_seed)(void *, unsigned long, unsigned long, unsigned long, char);
+    void (*set_seed)(void *, unsigned long, unsigned long, char, unsigned long);
 
     set_seed = dlsym(nledl->dlhandle, "nle_set_seed");
 
@@ -125,14 +125,14 @@ nle_set_seed(nledl_ctx *nledl, unsigned long core, unsigned long disp,
         exit(EXIT_FAILURE);
     }
 
-    set_seed(nledl->nle_ctx, core, disp, lgen, reseed);
+    set_seed(nledl->nle_ctx, core, disp,reseed, lgen);
 }
 
 void
 nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
-    unsigned long *lgen, char *reseed)
+    char *reseed, unsigned long *lgen)
 {
-    void (*get_seed)(void *, unsigned long *, unsigned long *, unsigned long *, char *);
+    void (*get_seed)(void *, unsigned long *, unsigned long *, char *, unsigned long *);
 
     get_seed = dlsym(nledl->dlhandle, "nle_get_seed");
 
@@ -145,5 +145,5 @@ nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
     /* Careful here. NetHack has different ideas of what a boolean is
      * than C++ (see global.h and SKIP_BOOLEAN). But one byte should be fine.
      */
-    get_seed(nledl->nle_ctx, core, disp, lgen, reseed);
+    get_seed(nledl->nle_ctx, core, disp, reseed, lgen);
 }

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -113,9 +113,9 @@ nle_end(nledl_ctx *nledl)
 
 void
 nle_set_seed(nledl_ctx *nledl, unsigned long core, unsigned long disp,
-             char reseed)
+    unsigned long lgen, char reseed)
 {
-    void (*set_seed)(void *, unsigned long, unsigned long, char);
+    void (*set_seed)(void *, unsigned long, unsigned long, unsigned long, char);
 
     set_seed = dlsym(nledl->dlhandle, "nle_set_seed");
 
@@ -125,14 +125,14 @@ nle_set_seed(nledl_ctx *nledl, unsigned long core, unsigned long disp,
         exit(EXIT_FAILURE);
     }
 
-    set_seed(nledl->nle_ctx, core, disp, reseed);
+    set_seed(nledl->nle_ctx, core, disp, lgen, reseed);
 }
 
 void
 nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
-             char *reseed)
+    unsigned long *lgen, char *reseed)
 {
-    void (*get_seed)(void *, unsigned long *, unsigned long *, char *);
+    void (*get_seed)(void *, unsigned long *, unsigned long *, unsigned long *, char *);
 
     get_seed = dlsym(nledl->dlhandle, "nle_get_seed");
 
@@ -145,5 +145,5 @@ nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
     /* Careful here. NetHack has different ideas of what a boolean is
      * than C++ (see global.h and SKIP_BOOLEAN). But one byte should be fine.
      */
-    get_seed(nledl->nle_ctx, core, disp, reseed);
+    get_seed(nledl->nle_ctx, core, disp, lgen, reseed);
 }

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -130,9 +130,9 @@ nle_set_seed(nledl_ctx *nledl, unsigned long core, unsigned long disp,
 
 void
 nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
-    char *reseed, unsigned long *lgen)
+    char *reseed, unsigned long *lgen, bool *lgen_in_use)
 {
-    void (*get_seed)(void *, unsigned long *, unsigned long *, char *, unsigned long *);
+    void (*get_seed)(void *, unsigned long *, unsigned long *, char *, unsigned long *, bool *);
 
     get_seed = dlsym(nledl->dlhandle, "nle_get_seed");
 
@@ -145,5 +145,5 @@ nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
     /* Careful here. NetHack has different ideas of what a boolean is
      * than C++ (see global.h and SKIP_BOOLEAN). But one byte should be fine.
      */
-    get_seed(nledl->nle_ctx, core, disp, reseed, lgen);
+    get_seed(nledl->nle_ctx, core, disp, reseed, lgen, lgen_in_use);
 }

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -113,9 +113,10 @@ nle_end(nledl_ctx *nledl)
 
 void
 nle_set_seed(nledl_ctx *nledl, unsigned long core, unsigned long disp,
-    char reseed, unsigned long lgen)
+             char reseed, unsigned long lgen)
 {
-    void (*set_seed)(void *, unsigned long, unsigned long, char, unsigned long);
+    void (*set_seed)(void *, unsigned long, unsigned long, char,
+                     unsigned long);
 
     set_seed = dlsym(nledl->dlhandle, "nle_set_seed");
 
@@ -125,14 +126,15 @@ nle_set_seed(nledl_ctx *nledl, unsigned long core, unsigned long disp,
         exit(EXIT_FAILURE);
     }
 
-    set_seed(nledl->nle_ctx, core, disp,reseed, lgen);
+    set_seed(nledl->nle_ctx, core, disp, reseed, lgen);
 }
 
 void
 nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
-    char *reseed, unsigned long *lgen, bool *lgen_in_use)
+             char *reseed, unsigned long *lgen, bool *lgen_in_use)
 {
-    void (*get_seed)(void *, unsigned long *, unsigned long *, char *, unsigned long *, bool *);
+    void (*get_seed)(void *, unsigned long *, unsigned long *, char *,
+                     unsigned long *, bool *);
 
     get_seed = dlsym(nledl->dlhandle, "nle_get_seed");
 

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -275,14 +275,14 @@ class Nethack
     }
 
     void
-    set_initial_seeds(unsigned long core, unsigned long disp, unsigned long lgen, bool reseed)
+    set_initial_seeds(unsigned long core, unsigned long disp,  bool reseed, unsigned long lgen, bool use_lgen_seed)
     {
         settings_.initial_seeds.seeds[0] = core;
         settings_.initial_seeds.seeds[1] = disp;
         settings_.initial_seeds.reseed = reseed;
         settings_.initial_seeds.use_init_seeds = true;
         settings_.initial_seeds.lgen_seed = lgen;
-        settings_.initial_seeds.use_lgen_seed = true;
+        settings_.initial_seeds.use_lgen_seed = use_lgen_seed;
     }
 
     void
@@ -293,17 +293,17 @@ class Nethack
         nle_set_seed(nle_, core, disp, reseed, lgen);
     }
 
-    std::tuple<unsigned long, unsigned long, unsigned long, bool>
+    std::tuple<unsigned long, unsigned long, bool, unsigned long>
     get_seeds()
     {
         if (!nle_)
             throw std::runtime_error("get_seed called without reset()");
-        std::tuple<unsigned long, unsigned long, unsigned long, bool> result;
+        std::tuple<unsigned long, unsigned long, bool, unsigned long> result;
         char
             reseed; /* NetHack's booleans are not necessarily C++ bools ... */
         nle_get_seed(nle_, &std::get<0>(result), &std::get<1>(result),
-                     &std::get<2>(result), &reseed);
-        std::get<3>(result) = reseed;
+                        &reseed, &std::get<3>(result));
+        std::get<2>(result) = reseed;
         return result;
     }
 

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -275,41 +275,35 @@ class Nethack
     }
 
     void
-    set_initial_seeds(unsigned long core, unsigned long disp, bool reseed)
+    set_initial_seeds(unsigned long core, unsigned long disp, unsigned long lgen, bool reseed)
     {
         settings_.initial_seeds.seeds[0] = core;
         settings_.initial_seeds.seeds[1] = disp;
         settings_.initial_seeds.reseed = reseed;
         settings_.initial_seeds.use_init_seeds = true;
-    }
-
-    void
-    set_initial_seeds(unsigned long core, unsigned long disp, bool reseed, unsigned long lgen)
-    {
         settings_.initial_seeds.lgen_seed = lgen;
         settings_.initial_seeds.use_lgen_seed = true;
-        set_initial_seeds(core, disp, reseed);
     }
 
     void
-    set_seeds(unsigned long core, unsigned long disp, bool reseed)
+    set_seeds(unsigned long core, unsigned long disp, bool reseed, unsigned long lgen)
     {
         if (!nle_)
             throw std::runtime_error("set_seed called without reset()");
-        nle_set_seed(nle_, core, disp, reseed);
+        nle_set_seed(nle_, core, disp, reseed, lgen);
     }
 
-    std::tuple<unsigned long, unsigned long, bool>
+    std::tuple<unsigned long, unsigned long, unsigned long, bool>
     get_seeds()
     {
         if (!nle_)
             throw std::runtime_error("get_seed called without reset()");
-        std::tuple<unsigned long, unsigned long, bool> result;
+        std::tuple<unsigned long, unsigned long, unsigned long, bool> result;
         char
             reseed; /* NetHack's booleans are not necessarily C++ bools ... */
         nle_get_seed(nle_, &std::get<0>(result), &std::get<1>(result),
-                     &reseed);
-        std::get<2>(result) = reseed;
+                     &std::get<2>(result), &reseed);
+        std::get<3>(result) = reseed;
         return result;
     }
 
@@ -397,10 +391,7 @@ PYBIND11_MODULE(_pynethack, m)
              py::arg("tty_colors") = py::none(),
              py::arg("tty_cursor") = py::none(), py::arg("misc") = py::none())
         .def("close", &Nethack::close)
-        .def("set_initial_seeds", py::overload_cast<unsigned long, unsigned long,
-            bool>(&Nethack::set_initial_seeds))
-        .def("set_initial_seeds", py::overload_cast<unsigned long, unsigned long,
-            bool, unsigned long>(&Nethack::set_initial_seeds))
+        .def("set_initial_seeds", &Nethack::set_initial_seeds)
         .def("set_seeds", &Nethack::set_seeds)
         .def("get_seeds", &Nethack::get_seeds)
         .def("in_normal_game", &Nethack::in_normal_game)

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -275,16 +275,17 @@ class Nethack
     }
 
     void
-    set_initial_seeds(unsigned long core, unsigned long disp,  bool reseed, py::object pyLgen)
+    set_initial_seeds(unsigned long core, unsigned long disp, bool reseed,
+                      py::object pyLgen)
     {
         settings_.initial_seeds.seeds[0] = core;
         settings_.initial_seeds.seeds[1] = disp;
         settings_.initial_seeds.reseed = reseed;
         settings_.initial_seeds.use_init_seeds = true;
 
-        /* The level generation seed's optional so may be passed as a Python None
-           object, if there isn't any seed. Also catches other rubbish that might
-           be passed in. */
+        /* The level generation seed's optional so may be passed as a Python
+           None object, if there isn't any seed. Also, catches other rubbish
+           that might be passed in. */
         try {
             settings_.initial_seeds.lgen_seed = pyLgen.cast<unsigned long>();
             settings_.initial_seeds.use_lgen_seed = true;
@@ -295,7 +296,8 @@ class Nethack
     }
 
     void
-    set_seeds(unsigned long core, unsigned long disp, bool reseed, py::object pyLgen)
+    set_seeds(unsigned long core, unsigned long disp, bool reseed,
+              py::object pyLgen)
     {
         if (!nle_)
             throw std::runtime_error("set_seed called without reset()");
@@ -304,7 +306,7 @@ class Nethack
         try {
             lgen = pyLgen.cast<unsigned long>();
         } catch (py::cast_error) {
-            /* Is 0 a valid seed number? Does nothing even matter? 
+            /* Is 0 a valid seed number? Does nothing even matter?
                A philosophical question for another day and time. */
             lgen = 0;
         }
@@ -316,20 +318,23 @@ class Nethack
     {
         if (!nle_)
             throw std::runtime_error("get_seed called without reset()");
-        
-        std::tuple<unsigned long, unsigned long, bool, unsigned long, bool> result;
-        char reseed; /* NetHack's booleans are not necessarily C++ bools ... */
-        
+
+        std::tuple<unsigned long, unsigned long, bool, unsigned long, bool>
+            result;
+
+        /* NetHack's booleans are not necessarily C++ bools ... */
+        char reseed; 
+
         nle_get_seed(nle_, &std::get<0>(result), &std::get<1>(result),
-                        &reseed, &std::get<3>(result), &std::get<4>(result));
-        
+                     &reseed, &std::get<3>(result), &std::get<4>(result));
+
         /* Package up the seeds as the level generation seed is optional */
         std::tuple<unsigned long, unsigned long, bool, py::object> seeds;
         std::get<0>(seeds) = std::get<0>(result);
         std::get<1>(seeds) = std::get<1>(result);
         std::get<2>(seeds) = reseed;
         /* Only want to return the level generation seed if it's in use */
-        if(std::get<4>(result)) {
+        if (std::get<4>(result)) {
             std::get<3>(seeds) = py::cast(std::get<3>(result));
         } else {
             std::get<3>(seeds) = py::none();

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -128,6 +128,7 @@ class Nethack
                     ttyrec.length() - found - 1);
 
         settings_.initial_seeds.use_init_seeds = false;
+        settings_.initial_seeds.use_lgen_seed = false;
     }
 
     Nethack(std::string dlpath, std::string hackdir,
@@ -283,6 +284,14 @@ class Nethack
     }
 
     void
+    set_initial_seeds(unsigned long core, unsigned long disp, bool reseed, unsigned long lgen)
+    {
+        settings_.initial_seeds.lgen_seed = lgen;
+        settings_.initial_seeds.use_lgen_seed = true;
+        set_initial_seeds(core, disp, reseed);
+    }
+
+    void
     set_seeds(unsigned long core, unsigned long disp, bool reseed)
     {
         if (!nle_)
@@ -387,7 +396,10 @@ PYBIND11_MODULE(_pynethack, m)
              py::arg("tty_colors") = py::none(),
              py::arg("tty_cursor") = py::none(), py::arg("misc") = py::none())
         .def("close", &Nethack::close)
-        .def("set_initial_seeds", &Nethack::set_initial_seeds)
+        .def("set_initial_seeds", py::overload_cast<unsigned long, unsigned long,
+            bool>(&Nethack::set_initial_seeds))
+        .def("set_initial_seeds", py::overload_cast<unsigned long, unsigned long,
+            bool, unsigned long>(&Nethack::set_initial_seeds))
         .def("set_seeds", &Nethack::set_seeds)
         .def("get_seeds", &Nethack::get_seeds)
         .def("in_normal_game", &Nethack::in_normal_game)

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -377,7 +377,7 @@ class Nethack
                              ttyrec ? ttyrec : ttyrec_, &settings_);
         } else
             nle_reset(nle_, &obs_, ttyrec, &settings_);
-        
+
         /* Once the seeds have been used, prevent them being reused. */
         settings_.initial_seeds.use_init_seeds = false;
         settings_.initial_seeds.use_lgen_seed = false;

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -323,7 +323,7 @@ class Nethack
             result;
 
         /* NetHack's booleans are not necessarily C++ bools ... */
-        char reseed;  
+        char reseed;
 
         nle_get_seed(nle_, &std::get<0>(result), &std::get<1>(result),
                      &reseed, &std::get<3>(result), &std::get<4>(result));

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -343,14 +343,15 @@ class Nethack
         if (!ttyrec)
             strncpy(settings_.ttyrecname, "", sizeof(settings_.ttyrecname));
 
-        bool *seeded = &(settings_.initial_seeds.use_init_seeds);
         if (!nle_) {
             nle_ = nle_start(dlpath_.c_str(), &obs_,
                              ttyrec ? ttyrec : ttyrec_, &settings_);
         } else
             nle_reset(nle_, &obs_, ttyrec, &settings_);
-        *seeded = false; /* Once the seeds have been used, prevent them being
-                            reused. */
+        
+        /* Once the seeds have been used, prevent them being reused. */
+        settings_.initial_seeds.use_init_seeds = false;
+        settings_.initial_seeds.use_lgen_seed = false;
 
         if (obs_.done)
             throw std::runtime_error("NetHack done right after reset");

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -323,7 +323,7 @@ class Nethack
             result;
 
         /* NetHack's booleans are not necessarily C++ bools ... */
-        char reseed; 
+        char reseed;  
 
         nle_get_seed(nle_, &std::get<0>(result), &std::get<1>(result),
                      &reseed, &std::get<3>(result), &std::get<4>(result));

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -304,6 +304,8 @@ class Nethack
         try {
             lgen = pyLgen.cast<unsigned long>();
         } catch (py::cast_error) {
+            /* Is 0 a valid seed number? Does nothing even matter? 
+               A philosophical question for another day and time. */
             lgen = 0;
         }
         nle_set_seed(nle_, core, disp, reseed, lgen);


### PR DESCRIPTION
This feature adds the capability to pass an extra parameter `lgen` to the NLE `seed()` function for the purposes of having a deterministic dungeon layout, while allowing the in-game play to be randomly guided (e.g. combat etc.)

It works by creating a new Random Number Generator using this seed value when the environment `reset()` function is called. This RNG is swapped with the NetHack `core` RNG during the level generation (see `maklev.c:1003`), where random numbers are sampled from the known RNG. It is then swapped back once the level is created (see `maklev.c:1041`), and subsequent random numbers will be sampled from `core`.

The RNGs are swapped again each time a new level is generated as the hero descends through the dungeon, ensuring that level generation random number sampling is kept separate from the in-game random number samples.