### PR TITLE
Add a devcontainer for easy debugging of Linux issues

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.12-slim
+
+# Install essential packages 
+RUN apt-get update && apt-get install -yq \
+    apt-transport-https \
+    bash-completion \
+    bison \
+    build-essential \
+    curl \
+    flex \
+    git \
+    libbz2-dev \
+    ninja-build \
+    sudo \
+    vim
+
+# Create non-root user
+RUN useradd -m -s /bin/bash vscode \
+    && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+    && mkdir -p /workspace \
+    && chown vscode:vscode /workspace \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Switch to non-root user
+USER vscode
+
+# Set up uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Set up environment variables
+ENV PATH="/home/vscode/.local/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+    "name": "Nethack Learning Environment Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff",
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/${workspaceFolder}/.venv/bin/python",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff",
+                    "editor.formatOnSave": true,
+                    "editor.codeActionsOnSave": {
+                        "source.organizeImports": "explicit"
+                    }
+                }
+            }
+        }
+    },
+    "mounts": [
+        "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+    ],
+    "remoteUser": "vscode",
+    "updateRemoteUserUID": true,
+    "remoteEnv": {
+        "UV_LINK_MODE": "copy"
+    }
+}


### PR DESCRIPTION
This PR allows code to be viewed and edited from a browser embedded vscode session by pressing '.' and allows the project to be opened in a Docker devcontainer locally in desktop vscode.

See: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers