### PR TITLE
Avoid duplicate setup of uv in test-and-deploy GitHub workflow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -16,10 +16,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
-      - name: Install Python ${{ matrix.python-version }} with the latest version of uv.
-        uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install the latest version of uv.
         uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
This is a bugfix and is already done as part of #79 