### PR TITLE
converter: fix EOF semantics and error propagation

### DIFF
--- a/third_party/converter/pyconverter.cc
+++ b/third_party/converter/pyconverter.cc
@@ -133,14 +133,17 @@ class Converter
             py::gil_scoped_release release;
             status = conversion_convert_frames(conversion_);
         }
-        if (status == -1) {
-            // TODO : Better error messages
-            throw std::runtime_error("Error in file.");
-        } else if (status == -2) {
+        if (status == CONV_CRITICAL_ERROR) {
+            throw std::runtime_error("Critical converter failure.");
+        } else if (status == CONV_HEADER_ERROR) {
             // ignore: status = -2
             // This occurs when convert is called on a converter that has
             // already been exhausted. This will be common in the last
             // minibatches in a dataset.
+        } else if (status == CONV_BODY_ERROR) {
+            throw std::runtime_error("Malformed ttyrec frame body.");
+        } else if (status == CONV_FILE_ERROR) {
+            throw std::runtime_error("Malformed ttyrec input.");
         }
         return conversion_->remaining;
     }


### PR DESCRIPTION
## Summary
- fix `ttyread()` to keep fully-read final frames when bzip reports `BZ_STREAM_END`
- tighten header/channel reads so only truly empty reads are treated as clean stream end
- map `CONV_BODY_ERROR` and `CONV_FILE_ERROR` to Python `RuntimeError` in `_pyconverter`
- add regression tests for final-frame commit and malformed header propagation

## Bugs fixed
- R5: final ttyrec frame can be silently dropped
- R6: converter body/file errors are swallowed in Python bindings

## Validation
- built `_pyconverter` target with CMake/Ninja
- ran Python reproductions:
  - single-frame ttyrec now commits action/timestamp (`remaining == 0`)
  - zero-length header now raises `RuntimeError: Malformed ttyrec input.`
