### PR TITLE
nle: avoid hackdir underflow on empty path

### DIFF
--- a/src/nle.c
+++ b/src/nle.c
@@ -183,7 +183,12 @@ mainloop(fcontext_transfer_t ctx_transfer)
                                 stack->ssize);
 #endif
 
-    int len = strnlen(settings.hackdir, sizeof(settings.hackdir));
+    size_t len = strnlen(settings.hackdir, sizeof(settings.hackdir));
+
+    if (len == 0) {
+        error("HACKDIR must not be empty");
+        return;
+    }
 
     if (len >= sizeof(settings.hackdir) - 1) {
         error("HACKDIR too long");


### PR DESCRIPTION
## Summary
- guard `len == 0` before accessing `settings.hackdir[len - 1]`
- keep existing normalization logic (`.../`) for non-empty paths
- fail fast with clear error when `HACKDIR` is empty

## Bugs fixed
- S1: `hackdir` underflow in `mainloop`

## Validation
- static code validation of the underflow path and normalization flow
- full build/test validation is blocked on GCC15 compatibility issue tracked in PR 10
