### PR TITLE
Localized suppression of compiler warnings and minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,6 @@ message(STATUS "Building nle backend version: ${CMAKE_NLE_VERSION}")
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-add_compile_options(-Wno-deprecated-non-prototype)
-add_compile_options(-Wno-unused-variable)
-
 set(HACKDIR
     "$ENV{HOME}/nethackdir.nle"
     CACHE STRING "Configuration files for nethack")
@@ -182,6 +179,9 @@ pybind11_add_module(
   $<TARGET_OBJECTS:tile>)
 target_link_libraries(_pynethack PUBLIC nethackdl)
 set_target_properties(_pynethack PROPERTIES CXX_STANDARD 14)
+if(NOT MSVC)
+  target_compile_options(_pynethack PRIVATE -Wno-deprecated-non-prototype)
+endif()
 target_include_directories(_pynethack PUBLIC ${NLE_INC_GEN} ${NLE_WIN}/share)
 # add_dependencies(_pynethack util tile) # For pm.h.
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -27,18 +27,37 @@ file(MAKE_DIRECTORY ${NLE_INC_GEN} ${NLE_SRC_GEN})
 add_executable(makedefs ${MAKEDEFS_SRC})
 target_include_directories(makedefs PRIVATE ${NLE_INC} ${NLE_INC_GEN}
                                             ${NLE_UTIL_GEN})
+if(NOT MSVC)
+  target_compile_options(makedefs PRIVATE -Wno-deprecated-non-prototype)
+endif()
+
 add_executable(dgn_comp ${DGN_COMP_SRC})
 target_include_directories(dgn_comp PRIVATE ${NLE_INC} ${NLE_INC_GEN}
                                             ${NLE_UTIL_GEN})
+if(NOT MSVC)
+  target_compile_options(dgn_comp PRIVATE -Wno-deprecated-non-prototype)
+endif()
+
 add_executable(lev_comp ${LEV_COMP_SRC})
 target_include_directories(lev_comp PRIVATE ${NLE_INC} ${NLE_INC_GEN}
                                             ${NLE_UTIL_GEN})
+if(NOT MSVC)
+  target_compile_options(lev_comp PRIVATE -Wno-deprecated-non-prototype)
+endif()
+
 add_executable(dlb ${DLB_SRC})
 target_include_directories(dlb PRIVATE ${NLE_INC} ${NLE_INC_GEN}
                                        ${NLE_UTIL_GEN})
+if(NOT MSVC)
+  target_compile_options(dlb PRIVATE -Wno-deprecated-non-prototype)
+endif()
+
 add_executable(recover recover.c)
 target_include_directories(recover PRIVATE ${NLE_INC} ${NLE_INC_GEN}
                                            ${NLE_UTIL_GEN})
+if(NOT MSVC)
+  target_compile_options(recover PRIVATE -Wno-deprecated-non-prototype)
+endif()
 
 add_custom_command(
   DEPENDS makedefs
@@ -91,6 +110,9 @@ add_custom_target(util DEPENDS ${MAKEDEFS_HEADERS} recover)
 add_executable(tilemap ${NLE_WIN}/share/tilemap.c)
 target_include_directories(tilemap PUBLIC ${NLE_INC} ${NLE_INC_GEN})
 add_dependencies(tilemap util)
+if(NOT MSVC)
+  target_compile_options(tilemap PRIVATE -Wno-deprecated-non-prototype)
+endif()
 
 file(GLOB NETHACK_TILE_SRC ${NLE_WIN}/rl/tile2rgb.c ${NLE_WIN}/rl/nletiletxt.c
      ${NLE_WIN}/share/tiletext.c)
@@ -98,6 +120,9 @@ add_library(tile OBJECT ${NETHACK_TILE_SRC} ${NLE_SRC_GEN}/tile.c)
 target_include_directories(tile PUBLIC ${NLE_INC} ${NLE_INC_GEN}
                                        ${NLE_WIN}/share)
 add_dependencies(tile generate_pm_h generate_tile_c)
+if(NOT MSVC)
+  target_compile_options(tile PRIVATE -Wno-deprecated-non-prototype)
+endif()
 
 # NOTE: util is dependent on these two
 add_dependencies(lev_comp util)

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -464,7 +464,7 @@ class Nethack
                 if (tile_index < 0 || tile_index >= total_tiles_used) {
                     fprintf(stderr,
                             "Invalid tile index %d for glyph %d at position "
-                            "(%ld,%ld)\n",
+                            "(%d,%d)\n",
                             tile_index, glyph, tile_row, tile_col);
                     continue;
                 }


### PR DESCRIPTION
* Suppress target-specific compiler warnings for non-MSVC builds

* Fix format specifier in error message