### PR TITLE
Remove old dependency check on version.txt file

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -166,12 +166,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Check version matches release tag
-        run: |
-          echo "v$(cat version.txt)"
-          echo "${{ github.event.release.tag_name }}"
-          [[ "${{ github.event.release.tag_name }}" == "v$(cat version.txt)" ]]
       - name: Get sdist artifact # Get sdist artifact from the test_sdist job
         uses: actions/download-artifact@v4
         with:
@@ -212,12 +206,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Check version matches release tag
-        run: |
-          echo "v$(cat version.txt)"
-          echo "${{ github.event.release.tag_name }}"
-          [[ "${{ github.event.release.tag_name }}" == "v$(cat version.txt)" ]]
       - name: Get sdist artifact # Get sdist artifact from the test_sdist job
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The `version.txt` file used to contain the published version of NLE, but this functionality was removed in PR #77.

This PR removes the dependency check on this file during test and release publication workflows.